### PR TITLE
feat: include logo SVGs in website bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ Outputs:
   - `site.webmanifest`
 - Namespaced (to avoid root clutter):
   - `brand/tokens.css`
-  - `brand/og/bitcraft-og.png`
+  - `brand/bitcraft-og.png`
+  - `brand/bitcraft-logo.svg`
+  - `brand/bitcraft-logo-mono-white.svg`
+  - `brand/bitcraft-logo-mono-black.svg`
 
 ### CI
 

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -292,6 +292,26 @@ async function exportTokens() {
   console.log(`  Created: ${path.relative(rootDir, tokensOutPath)}`);
 }
 
+async function copyLogos() {
+  console.log('Copying logo SVGs...');
+  const logoOutDir = path.join(brandDir, 'logo');
+  await fsp.mkdir(logoOutDir, { recursive: true });
+
+  const logos = [
+    'bitcraft-logo.svg',
+    'bitcraft-logo-mono-white.svg',
+    'bitcraft-logo-mono-black.svg',
+  ];
+
+  for (const logo of logos) {
+    const src = path.join(logoDir, logo);
+    const dest = path.join(logoOutDir, logo);
+    assertFileExists(src);
+    await fsp.copyFile(src, dest);
+    console.log(`  Copied: ${path.relative(rootDir, dest)}`);
+  }
+}
+
 // Moved main to bottom to allow for extracting color
 async function getThemeColor() {
   const palettePath = path.join(rootDir, 'colors', 'palette.md');
@@ -306,6 +326,7 @@ async function main() {
   await exportFavicons(themeColor);
   await exportOgImages();
   await exportTokens();
+  await copyLogos();
 
   console.log('\nBundle build complete.');
 }

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -294,9 +294,9 @@ async function exportTokens() {
 
 async function copyLogos() {
   console.log('Copying logo SVGs...');
-  const logoOutDir = path.join(brandDir, 'logo');
-  await fsp.mkdir(logoOutDir, { recursive: true });
 
+  // Core logo variants for website use (full-color + mono variants for light/dark backgrounds).
+  // Additional variants in logo/ (padded, single-color, lockups) are for other contexts.
   const logos = [
     'bitcraft-logo.svg',
     'bitcraft-logo-mono-white.svg',
@@ -305,7 +305,7 @@ async function copyLogos() {
 
   for (const logo of logos) {
     const src = path.join(logoDir, logo);
-    const dest = path.join(logoOutDir, logo);
+    const dest = path.join(brandDir, logo);
     assertFileExists(src);
     await fsp.copyFile(src, dest);
     console.log(`  Copied: ${path.relative(rootDir, dest)}`);

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -14,6 +14,14 @@ const logoDir = path.join(rootDir, 'logo');
 const faviconSourceSvg = path.join(logoDir, 'bitcraft-logo-padded.svg');
 const ogSourceSvg = path.join(logoDir, 'og-images', 'og-default.svg');
 
+// Core logo variants for website use (full-color + mono variants for light/dark backgrounds).
+// Additional variants in logo/ (padded, single-color, lockups) are for other contexts.
+const bundleLogos = [
+  'bitcraft-logo.svg',
+  'bitcraft-logo-mono-white.svg',
+  'bitcraft-logo-mono-black.svg',
+];
+
 const faviconPngOutputs = [
   { file: 'favicon-16x16.png', size: 16 },
   { file: 'favicon-32x32.png', size: 32 },
@@ -295,15 +303,7 @@ async function exportTokens() {
 async function copyLogos() {
   console.log('Copying logo SVGs...');
 
-  // Core logo variants for website use (full-color + mono variants for light/dark backgrounds).
-  // Additional variants in logo/ (padded, single-color, lockups) are for other contexts.
-  const logos = [
-    'bitcraft-logo.svg',
-    'bitcraft-logo-mono-white.svg',
-    'bitcraft-logo-mono-black.svg',
-  ];
-
-  for (const logo of logos) {
+  for (const logo of bundleLogos) {
     const src = path.join(logoDir, logo);
     const dest = path.join(brandDir, logo);
     assertFileExists(src);


### PR DESCRIPTION
## Summary

- Adds `copyLogos()` function to `build-bundle.js` that copies logo SVGs to `bundle/brand/`
- Enables automatic sync of logo assets to the website repository

## Changes

The build now outputs:
```
bundle/
└── brand/
    ├── bitcraft-logo.svg
    ├── bitcraft-logo-mono-white.svg
    ├── bitcraft-logo-mono-black.svg
    ├── bitcraft-og.png
    └── tokens.css
```

## Testing

Ran `npm run build` and verified output:
```
Copying logo SVGs...
  Copied: bundle/brand/bitcraft-logo.svg
  Copied: bundle/brand/bitcraft-logo-mono-white.svg
  Copied: bundle/brand/bitcraft-logo-mono-black.svg
```

Closes #32